### PR TITLE
Add Renovate configs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["github>rancher/renovate-config#release"],
+  "baseBranches": ["main"],
+  "prHourlyLimit": 2
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,25 @@
+name: Renovate
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: string
+      overrideSchedule:
+        description: "Override all schedules"
+        required: false
+        default: "false"
+        type: string
+  # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
+  #schedule:
+  #  - cron: '30 4,6 * * *'
+
+jobs:
+  call-workflow:
+    uses: rancher/renovate-config/.github/workflows/renovate.yml@release
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
+    secrets: inherit


### PR DESCRIPTION
Adds renovate with cron disabled for now.

I cannot locally test this in my fork due to needing all sorts of secrets.
And we can't test it in this repo without merging into `main` because only actions in "default branch" can be used.